### PR TITLE
Allow "-" when matching lora strengths to accomodate negative numbers

### DIFF
--- a/config_utils.py
+++ b/config_utils.py
@@ -218,7 +218,7 @@ def _expand_lora_weight_arrays(lora_string):
 
         # Check for bracket notation in strength values
         # Match pattern: name:[array_or_value]:[array_or_value] or name:[array_or_value]
-        bracket_match = re.search(r'\[[\d.,\s]+\]', part)
+        bracket_match = re.search(r'\[[\d.,\s-]+\]', part)
         if not bracket_match:
             # No arrays in this part, keep as-is
             parts_expansions.append([part])


### PR DESCRIPTION
This took a good bit of time to track down because the math of the number of comparisons I ended up with wasn't "mathing" for me. I was seeing an unexpected cartesian explosion when running through many loras.

I created a script that iterates through all of the loras on the filesystem and produces a config that can be consumed by this (awesome) tool. It sets a single weight like `lora.foo:[0.2,.04,0.6,0.8,1.0]`... MOST of the time. For specialized "slider" loras that act as positive or negative, I use `lora.foo:[-3,-1.5,0,1.5,3]` - and it turns out, that guy was causing issues.

This proposed tweak allows a `-` to appear in the bracket notation which, when detected, properly groups the loras resulting in comparisons like so:
* lora.foo:-3
* lora.foo:-1.5
* lora.foo:0
* lora.foo:1.5
* lora.foo:3

When this regex does NOT match, such slider loras create a cartesian product (I still haven't figured out why... but it does...... somewhere) so the actual comparisons end up like so:
* `lora.foo:-3:-3`
* `lora.foo:-3:-1.5`
* `lora.foo:-3:0`
* `lora.foo:-3:1.5`
* `lora.foo:-3:3`
* `lora.foo:-1.5:-3`
* `lora.foo:-1.5:3`
* `lora.foo:0:-3`
* `lora.foo:0:3`
* `lora.foo:1.5:-3`
* `lora.foo:1.5:3`
* `lora.foo:3:-3`
* `lora.foo:3:-1.5`
* `lora.foo:3:0`
* `lora.foo:3:1.5`
* `lora.foo:3:3`

If it weren't for the fantastic "revise mode", I wouldn't have detected this since most stylistic loras don't affect the CLIP at all - so it just visibly appeared to be a bunch of the same images!