### PR TITLE
Add "Additional Random Seeds" to config builder run settings

### DIFF
--- a/config_builder_node.py
+++ b/config_builder_node.py
@@ -876,6 +876,10 @@ class UltimateConfigBuilder:
         # session_name moves into session_settings too so the Generator's
         # session_name widget can be removed (Phase 2).
         session_settings["session_name"] = str(state.get("session_name", "my_session"))
+        try:
+            session_settings["add_random_seeds_to_gens"] = int(state.get("add_random_seeds_to_gens", 0))
+        except (TypeError, ValueError):
+            session_settings["add_random_seeds_to_gens"] = 0
 
         if session_settings:
             output_obj["_session_settings"] = session_settings

--- a/config_builder_node.py
+++ b/config_builder_node.py
@@ -1259,7 +1259,10 @@ async def get_model_lists_endpoint(request):
         checkpoints = folder_paths.get_filename_list("checkpoints")
         diffusion_models = folder_paths.get_filename_list("diffusion_models")
         text_encoders = folder_paths.get_filename_list("text_encoders")
-
+        try:
+            clip_models = folder_paths.get_filename_list("clip")
+        except (KeyError, Exception):
+            clip_models = []
         # GGUF lists - may not exist if ComfyUI-GGUF is not installed
         try:
             unet_gguf = folder_paths.get_filename_list("unet_gguf")
@@ -1270,16 +1273,40 @@ async def get_model_lists_endpoint(request):
         except (KeyError, Exception):
             clip_gguf = []
 
-        # CLIPType options (matching ComfyUI's CLIPLoader and DualCLIPLoader)
+        # CLIP type options: prefer ComfyUI runtime node definitions, fallback to known defaults.
         clip_types = [
             "stable_diffusion", "stable_cascade", "sd3", "stable_audio",
-            "mochi", "ltxv", "pixart", "cosmos", "lumina2", "wan",
+            "mochi", "ltxv", "pixart", "cosmos", "lumina2", "krea2", "wan",
             "hidream", "chroma", "ace", "flux", "flux2"
         ]
         dual_clip_types = [
             "sdxl", "sd3", "flux", "flux2", "hunyuan_video", "hidream",
             "hunyuan_image", "hunyuan_video_15"
         ]
+        try:
+            import nodes
+
+            def _extract_type_options(node_name):
+                node_cls = nodes.NODE_CLASS_MAPPINGS.get(node_name)
+                if not node_cls or not hasattr(node_cls, "INPUT_TYPES"):
+                    return None
+                input_types = node_cls.INPUT_TYPES() or {}
+                required = input_types.get("required") or {}
+                type_spec = required.get("type")
+                if isinstance(type_spec, (list, tuple)) and len(type_spec) > 0:
+                    options = type_spec[0]
+                    if isinstance(options, (list, tuple)):
+                        return [str(x) for x in options]
+                return None
+
+            runtime_clip_types = _extract_type_options("CLIPLoader")
+            runtime_dual_clip_types = _extract_type_options("DualCLIPLoader")
+            if runtime_clip_types:
+                clip_types = runtime_clip_types
+            if runtime_dual_clip_types:
+                dual_clip_types = runtime_dual_clip_types
+        except Exception:
+            pass
 
         # Upscale model list
         try:
@@ -1307,6 +1334,7 @@ async def get_model_lists_endpoint(request):
             "diffusion_models": diffusion_models,
             "unet_gguf": unet_gguf,
             "text_encoders": text_encoders,
+            "clip": clip_models,
             "clip_gguf": clip_gguf,
             "clip_types": clip_types,
             "dual_clip_types": dual_clip_types,

--- a/config_utils.py
+++ b/config_utils.py
@@ -412,6 +412,20 @@ def _expand_ltx_entry(entry):
     else:
         input_image_axis = to_list(raw_input_image) if raw_input_image is not None else [None]
 
+    # positive / negative: run through parse_prompt_input_nested so that nested
+    # array syntax from the Config Builder's Cartesian prompt builder is expanded
+    # correctly. Mirrors the same logic used in expand_configs() for the image path.
+    # A plain string passes through unchanged; [["p1", "p2"]] (Config Builder output)
+    # is treated as a flat list of 2 option strings → 2 separate video runs.
+    def _expand_prompt_field(raw):
+        if isinstance(raw, (list, tuple)):
+            result = parse_prompt_input_nested(json.dumps(list(raw)))
+        elif isinstance(raw, str) and raw.strip():
+            result = parse_prompt_input_nested(raw)
+        else:
+            result = [""]
+        return [str(p) for p in result]
+
     # All other fields: simple to_list
     field_axes = {
         "model": to_list(e.get("model", "")),
@@ -433,8 +447,8 @@ def _expand_ltx_entry(entry):
         "img_compression": to_list(e.get("img_compression", 18)),
         "audio_mode": to_list(e.get("audio_mode", "on")),
         "lora": to_list(e.get("lora", "None")),
-        "positive": to_list(e.get("positive", "")),
-        "negative": to_list(e.get("negative", "")),
+        "positive": _expand_prompt_field(e.get("positive", "")),
+        "negative": _expand_prompt_field(e.get("negative", "")),
         "width": to_list(e.get("width", 446)),
         "height": to_list(e.get("height", 576)),
     }

--- a/generation_orchestrator.py
+++ b/generation_orchestrator.py
@@ -1757,7 +1757,12 @@ def run_generation_loop(
             if job["latent"] is not None:
                 latent_in = {"samples": job["latent"]["samples"].clone()}
             else:
-                latent_in = {"samples": torch.zeros([1, latent_channels, h // 8, w // 8])}
+                latent_in = {
+                    "samples": torch.zeros([1, latent_channels, h // 8, w // 8]),
+                    # Mark the construction ratio so Comfy can remap to models
+                    # whose latent format uses a different spatial compression.
+                    "downscale_ratio_spacial": 8,
+                }
             
             result_latent = None
             try:
@@ -3143,7 +3148,12 @@ def _run_distributed_generation(
             if optional_latent is not None:
                 latent_in = {"samples": optional_latent["samples"].clone()}
             else:
-                latent_in = {"samples": torch.zeros([1, latent_channels, h // 8, w // 8])}
+                latent_in = {
+                    "samples": torch.zeros([1, latent_channels, h // 8, w // 8]),
+                    # Mark the construction ratio so Comfy can remap to models
+                    # whose latent format uses a different spatial compression.
+                    "downscale_ratio_spacial": 8,
+                }
 
             # --- Generate Image ---
             try:

--- a/image_generation.py
+++ b/image_generation.py
@@ -338,7 +338,12 @@ def generate_image(
             # Execute SamplerCustomAdvanced
             latent = latent_input.copy()
             latent_image = latent["samples"]
-            latent_image = comfy.sample.fix_empty_latent_channels(guider.model_patcher, latent_image)
+            latent_image = comfy.sample.fix_empty_latent_channels(
+                guider.model_patcher,
+                latent_image,
+                latent.get("downscale_ratio_spacial", None),
+                latent.get("downscale_ratio_temporal", None),
+            )
             latent["samples"] = latent_image
 
             noise_mask = latent.get("noise_mask")

--- a/sampler_node.py
+++ b/sampler_node.py
@@ -320,6 +320,12 @@ class SamplerGridTester:
             if "session_name" in session_settings:
                 session_name = str(session_settings["session_name"])
                 print(f"[GridTester] ⚙️ session_name overridden by Builder UI: {session_name}")
+            if "add_random_seeds_to_gens" in session_settings:
+                try:
+                    add_random_seeds_to_gens = int(session_settings["add_random_seeds_to_gens"])
+                    print(f"[GridTester] ⚙️ add_random_seeds_to_gens overridden by Builder UI: {add_random_seeds_to_gens}")
+                except (TypeError, ValueError):
+                    pass
 
         return run_generation_loop(
             self,

--- a/tests/test_ltx_config_expansion.py
+++ b/tests/test_ltx_config_expansion.py
@@ -259,3 +259,81 @@ def test_input_image_string_no_trailing_slash_unchanged(tmp_path):
     result = _call(base)
     assert len(result) == 1
     assert result[0]["input_image"] == "/tmp/single.png"
+
+
+
+# ---------------------------------------------------------------------------
+# Prompt field handling — Config Builder nested array format
+# ---------------------------------------------------------------------------
+
+def test_positive_plain_string_passes_through():
+    """A plain string positive prompt yields exactly one config with that string."""
+    base = _ltx_base()
+    base["positive"] = "a cat on a rooftop"
+    result = _call(base)
+    assert len(result) == 1
+    assert result[0]["positive"] == "a cat on a rooftop"
+
+
+def test_positive_config_builder_nested_array_two_prompts():
+    """Config Builder wraps prompts in [["p1", "p2"]]. Each inner string → a separate run."""
+    base = _ltx_base()
+    base["positive"] = [["prompt one", "prompt two"]]
+    result = _call(base)
+    assert len(result) == 2
+    prompts = sorted(c["positive"] for c in result)
+    assert prompts == ["prompt one", "prompt two"]
+
+
+def test_positive_config_builder_single_prompt_in_nested_array():
+    """[["single prompt"]] collapses to a single run."""
+    base = _ltx_base()
+    base["positive"] = [["only one prompt"]]
+    result = _call(base)
+    assert len(result) == 1
+    assert result[0]["positive"] == "only one prompt"
+
+
+def test_positive_flat_array_two_strings():
+    """A flat list of two strings produces two separate runs."""
+    base = _ltx_base()
+    base["positive"] = ["option A", "option B"]
+    result = _call(base)
+    assert len(result) == 2
+    prompts = sorted(c["positive"] for c in result)
+    assert prompts == ["option A", "option B"]
+
+
+def test_positive_is_always_a_string_after_expansion():
+    """Regardless of input format, every expanded config must have a str positive."""
+    base = _ltx_base()
+    base["positive"] = [["p1", "p2"]]
+    result = _call(base)
+    for c in result:
+        assert isinstance(c["positive"], str), "positive must be a plain string after expansion"
+
+
+def test_negative_config_builder_nested_array():
+    """Nested array negative follows the same expansion logic as positive."""
+    base = _ltx_base()
+    base["negative"] = [["bad quality", "blurry, ugly"]]
+    result = _call(base)
+    assert len(result) == 2
+    negs = sorted(c["negative"] for c in result)
+    assert negs == ["bad quality", "blurry, ugly"]
+
+
+def test_positive_and_negative_nested_arrays_cross():
+    """Two positive prompts × two negative prompts → 4 configs (Cartesian product)."""
+    base = _ltx_base()
+    base["positive"] = [["pos1", "pos2"]]
+    base["negative"] = [["neg1", "neg2"]]
+    result = _call(base)
+    assert len(result) == 4
+    combos = sorted((c["positive"], c["negative"]) for c in result)
+    assert combos == [
+        ("pos1", "neg1"),
+        ("pos1", "neg2"),
+        ("pos2", "neg1"),
+        ("pos2", "neg2"),
+    ]

--- a/tests/test_ltx_config_expansion.py
+++ b/tests/test_ltx_config_expansion.py
@@ -173,7 +173,83 @@ def test_input_image_folder_nonexistent_passes_through(tmp_path):
     result = _call(base)
     # Treated as single string since the folder doesn't exist; not expanded
     assert len(result) == 1
-    assert result[0]["input_image"].endswith("/")
+
+
+# ---------------------------------------------------------------------------
+# Prompt field handling — Config Builder nested array format
+# ---------------------------------------------------------------------------
+
+def test_positive_plain_string_passes_through():
+    """A plain string positive prompt yields exactly one config with that string."""
+    base = _ltx_base()
+    base["positive"] = "a cat on a rooftop"
+    result = _call(base)
+    assert len(result) == 1
+    assert result[0]["positive"] == "a cat on a rooftop"
+
+
+def test_positive_config_builder_nested_array_two_prompts():
+    """Config Builder wraps prompts in [["p1", "p2"]]. Each inner string → a separate run."""
+    base = _ltx_base()
+    base["positive"] = [["prompt one", "prompt two"]]
+    result = _call(base)
+    assert len(result) == 2
+    prompts = sorted(c["positive"] for c in result)
+    assert prompts == ["prompt one", "prompt two"]
+
+
+def test_positive_config_builder_single_prompt_in_nested_array():
+    """[["single prompt"]] collapses to a single run."""
+    base = _ltx_base()
+    base["positive"] = [["only one prompt"]]
+    result = _call(base)
+    assert len(result) == 1
+    assert result[0]["positive"] == "only one prompt"
+
+
+def test_positive_flat_array_two_strings():
+    """A flat list of two strings produces two separate runs."""
+    base = _ltx_base()
+    base["positive"] = ["option A", "option B"]
+    result = _call(base)
+    assert len(result) == 2
+    prompts = sorted(c["positive"] for c in result)
+    assert prompts == ["option A", "option B"]
+
+
+def test_positive_is_always_a_string_after_expansion():
+    """Regardless of input format, every expanded config must have a str positive."""
+    base = _ltx_base()
+    base["positive"] = [["p1", "p2"]]
+    result = _call(base)
+    for c in result:
+        assert isinstance(c["positive"], str), "positive must be a plain string after expansion"
+
+
+def test_negative_config_builder_nested_array():
+    """Nested array negative follows the same expansion logic as positive."""
+    base = _ltx_base()
+    base["negative"] = [["bad quality", "blurry, ugly"]]
+    result = _call(base)
+    assert len(result) == 2
+    negs = sorted(c["negative"] for c in result)
+    assert negs == ["bad quality", "blurry, ugly"]
+
+
+def test_positive_and_negative_nested_arrays_cross():
+    """Two positive prompts × two negative prompts → 4 configs (Cartesian product)."""
+    base = _ltx_base()
+    base["positive"] = [["pos1", "pos2"]]
+    base["negative"] = [["neg1", "neg2"]]
+    result = _call(base)
+    assert len(result) == 4
+    combos = sorted((c["positive"], c["negative"]) for c in result)
+    assert combos == [
+        ("pos1", "neg1"),
+        ("pos1", "neg2"),
+        ("pos2", "neg1"),
+        ("pos2", "neg2"),
+    ]
 
 
 def test_input_image_string_no_trailing_slash_unchanged(tmp_path):

--- a/web/conf_builder/conf-builder-config-management.js
+++ b/web/conf_builder/conf-builder-config-management.js
@@ -3093,8 +3093,11 @@ function renderTextEncodersSection(node, container, configArray, arrayIdx, model
             teRow.appendChild(teBypassLabel);
         }
 
+        const teOptions = (modelLists.textEncoders && modelLists.textEncoders.length > 0)
+            ? modelLists.textEncoders
+            : ["None"];
         const teSearchable = createSearchableSelect(
-            modelLists.textEncoders || ["None"],
+            teOptions,
             te || "None",
             (value) => {
                 node.state.config_arrays[arrayIdx].text_encoders[teIdx] = normalizePath(value);

--- a/web/conf_builder/conf-builder-config-management.js
+++ b/web/conf_builder/conf-builder-config-management.js
@@ -6878,6 +6878,7 @@ export function renderRunSettingsSection(node, container) {
     if (node.state.save_conditioning_cache_to_file === undefined) node.state.save_conditioning_cache_to_file = false;
     if (node.state.enable_model_cache === undefined) node.state.enable_model_cache = false;
     if (node.state.vae_batch_size === undefined) node.state.vae_batch_size = 1;
+    if (node.state.add_random_seeds_to_gens === undefined) node.state.add_random_seeds_to_gens = 0;
 
     const section = document.createElement("div");
     section.className = "cb-section full-width";
@@ -7035,6 +7036,8 @@ export function renderRunSettingsSection(node, container) {
         tooltip: "Experimental: intelligent model/LoRA caching with async background preloading. Speeds up generation when switching LoRAs frequently. Loads cached LoRAs from RAM instead of disk. Disable to reduce RAM/VRAM usage." });
     _addRunSetting(content, { stateKey: "vae_batch_size", label: "VAE Batch Size", kind: "int", min: -1, max: 64, defaultValue: 1,
         tooltip: "How many images to encode/decode per VAE pass. Lower = less VRAM. -1 = process all at once. Default: 4." });
+    _addRunSetting(content, { stateKey: "add_random_seeds_to_gens", label: "Additional Random Seeds", kind: "int", min: 0, max: 100, defaultValue: 0,
+        tooltip: "Generate this many extra images per config using additional random seeds. 0 = disabled." });
 
     section.appendChild(header);
     section.appendChild(content);

--- a/web/conf_builder/conf-builder-utilities.js
+++ b/web/conf_builder/conf-builder-utilities.js
@@ -41,7 +41,7 @@ const LS_CACHE_KEY = "uscg_model_cache";
 const LS_COUNTS_KEY = "uscg_model_counts";
 // Bump this whenever the cache shape changes (new field added, structure tweaked).
 // Mismatched versions force a fresh fetch instead of restoring incomplete data.
-const LS_CACHE_VERSION = 2;
+const LS_CACHE_VERSION = 3;
 
 function _saveToLocalStorage() {
     try {
@@ -677,18 +677,29 @@ export function convertConfigsToConfigArrays(configs) {
             }
         });
 
-        let models = config.model;
+        // Accept both schemas:
+        // 1) runtime configs_json: model + model_type
+        // 2) builder-save schema: models[] entries (string or {path, type})
+        let models = config.models !== undefined ? config.models : config.model;
         if (!Array.isArray(models)) models = models ? [models] : ["None"];
 
-        // Determine model type from config
+        // Determine model type from config (runtime schema fallback)
         const loadedModelType = config.model_type || "checkpoint";
 
-        // Convert models to object format if non-checkpoint, keep string for checkpoint
-        if (loadedModelType !== "checkpoint") {
-            models = models.map(m => ({ path: normalizePath(m), type: loadedModelType }));
-        } else {
-            models = models.map(normalizePath);
-        }
+        models = models.map((m) => {
+            // Builder schema object entry: preserve explicit per-entry type
+            if (typeof m === "object" && m !== null) {
+                const path = normalizePath(m.path || "None");
+                const type = m.type || loadedModelType || "checkpoint";
+                return type === "checkpoint" ? path : { path, type };
+            }
+
+            // Primitive entry: use runtime model_type convention
+            const normalized = normalizePath(m);
+            return loadedModelType === "checkpoint"
+                ? normalized
+                : { path: normalized, type: loadedModelType };
+        });
 
         // Normalize loaded loras
         loras = loras.map(normalizePath);


### PR DESCRIPTION
I noticed that the ability to override, per run, additional random seeds was missing from the config builder. I don't always use the setting, but it's useful for testing lora strengths by varying the base image (in other words: does the result look horrible because the model made it that way, or the lora did? 😆 ). Since all the plumbing was still in place, I figure it just got missed when porting the generator node settings over to the run settings in config builder.